### PR TITLE
separate closed and opened scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## v0.2.0
+
+- Breaking change: separated closed and opened scope. Replace:
+
+```rust
+let mut scope = WhateverScope::new(...);
+scope.open(...);
+scope.enter(...);
+```
+
+with:
+
+```rust
+let scope = WhateverScope::new(...); // removed the mut
+let mut scope = scope.open(...); // re-assign the scope
+scope.enter(...); // unchanged
+```
+
+- Fix a panic that would occur when dropping an unopened scope.
+
+## v0.1.0
+
+- Initial version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nolife"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Crate to open a scope and then freeze it in time for future access."

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ After you identified the data and its borrowed representation that you'd like to
      #                           /* 👆 reference to the borrowed data */
      #     }
      # }
-     let mut scope = nolife::BoxScope::new();
-     scope.open(|time_capsule| my_scope(time_capsule, vec![0, 1, 2]));
+     let scope = nolife::BoxScope::new();
+     let mut scope = scope.open(|time_capsule| my_scope(time_capsule, vec![0, 1, 2]));
      // You can now store the open scope anywhere you want.
      ```
 
@@ -108,8 +108,8 @@ After you identified the data and its borrowed representation that you'd like to
      #                           /* 👆 reference to the borrowed data */
      #     }
      # }
-     # let mut scope = nolife::BoxScope::new();
-     # scope.open(|time_capsule| my_scope(time_capsule, vec![0, 1, 2]));
+     # let scope = nolife::BoxScope::new();
+     # let mut scope = scope.open(|time_capsule| my_scope(time_capsule, vec![0, 1, 2]));
      scope.enter(|parsed_data| { /* do what you need with the parsed data */ });
      ```
 
@@ -126,7 +126,7 @@ An `RcScope` and a `MutexScope` could
 
 # Inner async support
 
-At the moment, although the functions passed to [`BoxScope::open`] are asynchronous, they should not `await` futures other than the [`FrozenFuture`]. Attempting to do so **will result in a panic** if the future does not resolve immediately.
+At the moment, although the functions passed to [`ClosedBoxScope::open`] are asynchronous, they should not `await` futures other than the [`FrozenFuture`]. Attempting to do so **will result in a panic** if the future does not resolve immediately.
 
 Future versions of this crate could provide async version of [`BoxScope::enter`] to handle the asynchronous use case.
 

--- a/src/box_scope.rs
+++ b/src/box_scope.rs
@@ -6,11 +6,67 @@ use crate::{Family, Never, Scope, TimeCapsule};
 ///
 /// Contrary to [`crate::StackScope`], this kind of scopes uses a dynamic allocation.
 /// In exchange, it is fully `'static` and can be moved after creation.
+///
+/// This scope was already opened from a [`ClosedBoxScope`] and can now be [`BoxScope::enter`]ed.
 #[repr(transparent)]
 pub struct BoxScope<T, F>(std::ptr::NonNull<Scope<T, F>>)
 where
     T: for<'a> Family<'a>,
     F: Future<Output = Never>;
+
+/// An unopened, dynamic scope tied to a Box.
+///
+/// Contrary to [`crate::StackScope`], this kind of scopes uses a dynamic allocation.
+/// In exchange, it is fully `'static` and can be moved after creation.
+///
+/// Use [`ClosedBoxScope::open`] to open this scope and further use it.
+pub struct ClosedBoxScope<T, F>(std::ptr::NonNull<Scope<T, F>>)
+where
+    T: for<'a> Family<'a>,
+    F: Future<Output = Never>;
+
+impl<T, F> Drop for ClosedBoxScope<T, F>
+where
+    T: for<'a> Family<'a>,
+    F: Future<Output = Never>,
+{
+    fn drop(&mut self) {
+        unsafe { drop(Box::from_raw(self.0.as_ptr())) }
+    }
+}
+
+impl<T, F> ClosedBoxScope<T, F>
+where
+    T: for<'a> Family<'a>,
+    F: Future<Output = Never>,
+{
+    /// Creates a new unopened scope.
+    pub fn new() -> Self {
+        let b = Box::new(Scope::new());
+        let b = Box::leak(b);
+        Self(b.into())
+    }
+
+    /// Opens this scope, making it possible to call [`BoxScope::enter`] on the scope.
+    ///
+    /// # Panics
+    ///
+    /// - If `producer` panics.
+    pub fn open<P>(self, producer: P) -> BoxScope<T, F>
+    where
+        P: FnOnce(TimeCapsule<T>) -> F,
+    {
+        // SAFETY: `self.0` is dereference-able due to coming from a `Box`.
+        unsafe { Scope::open(self.0, producer) }
+
+        let open_scope = BoxScope(self.0);
+
+        // SAFETY: don't call drop on self to avoid double-free since the resource of self was moved to `open_scope`
+        std::mem::forget(self);
+
+        open_scope
+    }
+}
 
 impl<T, F> Drop for BoxScope<T, F>
 where
@@ -24,6 +80,7 @@ where
         // destructor after releasing its backing memory, causing uaf
         {
             let mut fut = this.active_fut.borrow_mut();
+            // unwrap: fut was set in open
             let fut = fut.as_mut().unwrap();
             unsafe { ManuallyDrop::drop(fut) };
         }
@@ -37,30 +94,14 @@ where
     F: Future<Output = Never>,
 {
     /// Creates a new unopened scope.
-    pub fn new() -> Self {
-        let b = Box::new(Scope::new());
-        let b = Box::leak(b);
-        Self(b.into())
-    }
-
-    /// Opens this scope, making it possible to call [`Self::enter`] on the scope.
-    ///
-    /// # Panics
-    ///
-    /// - If this method is called on an already opened scope.
-    pub fn open<P>(&mut self, producer: P)
-    where
-        P: FnOnce(TimeCapsule<T>) -> F,
-    {
-        // SAFETY: `self.0` is dereference-able due to coming from a `Box`.
-        unsafe { Scope::open(self.0, producer) }
+    pub fn new() -> ClosedBoxScope<T, F> {
+        ClosedBoxScope::new()
     }
 
     /// Enters the scope, making it possible to access the data frozen inside of the scope.
     ///
     /// # Panics
     ///
-    /// - If this method is called on an unopened scope.
     /// - If the passed function panics.
     /// - If the underlying future panics.
     /// - If the underlying future awaits for a future other than the [`crate::FrozenFuture`].

--- a/src/counterexamples.rs
+++ b/src/counterexamples.rs
@@ -22,8 +22,8 @@
 //! fn covariant_inner() {
 //!     {
 //!         let mut scope = Scope::new();
-//!         let mut scope = unsafe { StackScope::new_unchecked(&mut scope) };
-//!         scope.open(
+//!         let scope = unsafe { StackScope::new_unchecked(&mut scope) };
+//!         let mut scope = scope.open(
 //!             |mut time_capsule: TimeCapsule<CovariantFamily>| async move {
 //!                 let mut f = Covariant { x: "bbb" };
 //!                 loop {
@@ -63,8 +63,8 @@
 //!     let output = Cell::new("foo");
 //!     {
 //!         let mut scope = Scope::new();
-//!         let mut scope = unsafe { StackScope::new_unchecked(&mut scope) };
-//!         scope.open(
+//!         let scope = unsafe { StackScope::new_unchecked(&mut scope) };
+//!         let mut scope = scope.open(
 //!             |mut time_capsule: TimeCapsule<CovariantFamily>| async move {
 //!                 let mut f = Covariant { x: "bbb" };
 //!                 loop {
@@ -102,8 +102,8 @@
 //!
 //! fn box_covariant_inner() {
 //!     {
-//!         let mut scope = BoxScope::new();
-//!         scope.open(
+//!         let scope = BoxScope::new();
+//!         let mut scope = scope.open(
 //!             |mut time_capsule: TimeCapsule<CovariantFamily>| async move {
 //!                 let x = String::from("aaaaa");
 //!                 let mut f = Covariant { x: &x };
@@ -142,8 +142,8 @@
 //! fn box_covariant_outer() {
 //!     let outer = Cell::new("foo");
 //!     {
-//!         let mut scope = BoxScope::new();
-//!         scope.open(
+//!         let scope = BoxScope::new();
+//!         let mut scope = scope.open(
 //!             |mut time_capsule: TimeCapsule<CovariantFamily>| async move {
 //!                 let x = String::from("aaaaa");
 //!                 let mut f = Covariant { x: &x };
@@ -185,10 +185,9 @@
 //!     {
 //!         let mut scope = Scope::new();
 //!
-//!         let mut scope = unsafe { StackScope::new_unchecked(&mut scope) };
-//!         let outer = String::from("outer");
+//!         let scope = unsafe { StackScope::new_unchecked(&mut scope) };
 //!
-//!         scope.open(
+//!         let mut scope = scope.open(
 //!             |mut time_capsule: TimeCapsule<CovariantDropFamily>| async move {
 //!                 let mut f = CovariantDrop { x: "inner" };
 //!                 loop {
@@ -197,6 +196,9 @@
 //!                 }
 //!             },
 //!         );
+//!
+//!         let outer = String::from("outer");
+//!
 //!
 //!         {
 //!             scope.enter(|f| {
@@ -226,10 +228,10 @@
 //!     let outer: Cell<&str> = Cell::new("toto");
 //!
 //!     let mut scope = nolife::Scope::new();
-//!     let mut scope = unsafe { nolife::StackScope::new_unchecked(&mut scope) };
+//!     let scope = unsafe { nolife::StackScope::new_unchecked(&mut scope) };
 //!
 //!     {
-//!         scope.open(
+//!         let mut scope = scope.open(
 //!             |mut time_capsule: nolife::TimeCapsule<ContravariantFamily>| async move {
 //!                 loop {
 //!                     let mut x = String::from("inner");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@ mod stack_scope;
 /// [genawaiter](https://lib.rs/crates/genawaiter).
 mod waker;
 
-pub use box_scope::BoxScope;
-pub use stack_scope::StackScope;
+pub use box_scope::{BoxScope, ClosedBoxScope};
+pub use stack_scope::{ClosedStackScope, StackScope};
 
 use std::{
     cell::{Cell, RefCell},
@@ -26,7 +26,7 @@ use std::{
 ///
 /// Since this enum has no variant, a value of this type can never actually exist.
 /// This type is similar to [`std::convert::Infallible`] and used as a technicality to ensure that
-/// functions passed to [`BoxScope::open`] and [`StackScope::open`] never return.
+/// functions passed to [`ClosedBoxScope::open`] and [`ClosedStackScope::open`] never return.
 ///
 /// ## Future compatibility
 ///

--- a/src/stack_scope.rs
+++ b/src/stack_scope.rs
@@ -2,7 +2,7 @@ use std::{future::Future, marker::PhantomData, mem::ManuallyDrop};
 
 use crate::{Family, Never, Scope, TimeCapsule};
 
-/// A scope that is tied to a syntactic scope.
+/// An opened scope that is tied to a syntactic scope.
 ///
 /// Spawning such a scope is `unsafe`, as it requires the underlying [`Scope`] object to remain pinned for the entirety
 /// of its lifetime after being passed to a [`StackScope`] (see [`StackScope::new_unchecked`] for more information).
@@ -15,7 +15,20 @@ where
     T: for<'b> Family<'b>,
     F: Future<Output = Never>;
 
-impl<'a, T, F> StackScope<'a, T, F>
+/// An unopened scope that is tied to a syntactic scope.
+///
+/// Spawning such a scope is `unsafe`, as it requires the underlying [`Scope`] object to remain pinned for the entirety
+/// of its lifetime after being passed to a [`ClosedStackScope`] (see [`ClosedStackScope::new_unchecked`] for more information).
+#[repr(transparent)]
+pub struct ClosedStackScope<'a, T, F>(
+    std::ptr::NonNull<Scope<T, F>>,
+    PhantomData<&'a mut dyn Fn(&'a mut F)>,
+)
+where
+    T: for<'b> Family<'b>,
+    F: Future<Output = Never>;
+
+impl<'a, T, F> ClosedStackScope<'a, T, F>
 where
     T: for<'b> Family<'b>,
     F: Future<Output = Never>,
@@ -32,24 +45,41 @@ where
         Self(scope.into(), PhantomData)
     }
 
-    /// Opens this scope, making it possible to call [`Self::enter`] on the scope.
-    ///
-    /// # Panics
-    ///
-    /// - If this method is called on an already opened scope.
-    pub fn open<P>(&mut self, producer: P)
+    /// Opens this scope, making it possible to call [`StackScope::enter`] on the scope.
+    pub fn open<P>(self, producer: P) -> StackScope<'a, T, F>
     where
         P: FnOnce(TimeCapsule<T>) -> F,
     {
         // SAFETY: `self.0` is dereference-able if the `new_unchecked` preconditions are met.
         unsafe { Scope::open(self.0, producer) }
+
+        let open_scope = StackScope(self.0, PhantomData);
+
+        open_scope
+    }
+}
+
+impl<'a, T, F> StackScope<'a, T, F>
+where
+    T: for<'b> Family<'b>,
+    F: Future<Output = Never>,
+{
+    /// Create a new unopened scope from borrowing a low-level [`Scope`] object.
+    ///
+    /// ## Safety
+    ///
+    /// - Although this crate does not use `pin`, the passed scope **must** provide the same guarantees as if it had been pinned.
+    /// - As an additional soundness condition, the passed scope **shall not** be reused for another call to `new_unchecked`.
+    ///
+    /// The [`crate::stack_scope!`] and [`crate::open_stack_scope!`] macros provides a safe way of spawning a [`StackScope`].
+    pub unsafe fn new_unchecked(scope: &'a mut Scope<T, F>) -> ClosedStackScope<'a, T, F> {
+        ClosedStackScope::new_unchecked(scope)
     }
 
     /// Enters the scope, making it possible to access the data frozen inside of the scope.
     ///
     /// # Panics
     ///
-    /// - If this method is called on an unopened scope.
     /// - If the passed function panics.
     /// - If the underlying future panics.
     /// - If the underlying future awaits for a future other than the [`crate::FrozenFuture`].
@@ -62,7 +92,7 @@ where
     }
 }
 
-/// Safely creates a [`StackScope`].
+/// Safely creates a [`ClosedStackScope`].
 ///
 /// # Example
 ///
@@ -70,7 +100,7 @@ where
 /// use nolife::{SingleFamily, TimeCapsule, stack_scope};
 ///
 /// stack_scope!(scope);
-/// scope.open(|mut time_capsule: TimeCapsule<SingleFamily<u32>>| async move {
+/// let mut scope = scope.open(|mut time_capsule: TimeCapsule<SingleFamily<u32>>| async move {
 ///         let mut x = 0u32;
 ///         loop {
 ///             time_capsule.freeze(&mut x).await;
@@ -88,11 +118,11 @@ macro_rules! stack_scope {
     ($id:ident) => {
         let mut $id = $crate::Scope::new();
         // SAFETY: the original identifier is shadowed, ensuring it is never reused.
-        let mut $id = unsafe { $crate::StackScope::new_unchecked(&mut $id) };
+        let $id = unsafe { $crate::StackScope::new_unchecked(&mut $id) };
     };
 }
 
-/// Convenience macro to safely create a [`StackScope`] and open it on the spot.
+/// Convenience macro to safely create an opened [`StackScope`].
 ///
 /// # Example
 ///
@@ -118,7 +148,7 @@ macro_rules! stack_scope {
 macro_rules! open_stack_scope {
     ($id: ident = $async_func: expr) => {
         $crate::stack_scope!($id);
-        $id.open($async_func);
+        let mut $id = $id.open($async_func);
     };
 }
 
@@ -131,6 +161,7 @@ where
         // SAFETY: `self.0` is dereference-able if the `new_unchecked` preconditions are met.
         let this = unsafe { self.0.as_ref() };
         let mut fut = this.active_fut.borrow_mut();
+        // fut is not None because it was set in open
         let fut = fut.as_mut().unwrap();
         unsafe { ManuallyDrop::drop(fut) };
     }


### PR DESCRIPTION
- Breaking change: separated closed and opened scope. Replace:

```rust
let mut scope = WhateverScope::new(...);
scope.open(...);
scope.enter(...);
```

with:

```rust
let scope = WhateverScope::new(...); // removed the mut
let mut scope = scope.open(...); // re-assign the scope
scope.enter(...); // unchanged
```

- Fix a panic that would occur when dropping an unopened scope.

