### PR TITLE
`FrozenFuture` no longer resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.4.0
+
+- Breaking change:
+  - ⚠️ The `FrozenFuture` no longer return `Poll::Ready`, alleviating the need for a `loop` around the `freeze` call.
+    ⚠️ Code using a loop **will keep compiling** ⚠️, but any statement after the first `freeze` **is now unreachable**.
+  ```rust
+    async fn my_scope(mut time_capsule: nolife::TimeCapsule<MyParsedDataFamily, data_source: Vec<u8>)
+    -> nolife::Never {
+       let mut data = MyData(data_source);
+       let mut parsed_data = MyParsedData(&mut data);
+       loop {
+          time_capsule.freeze(&mut parsed_data).await; // 👈 ⚠️ No longer returns
+          // ⚠️ Now unreachble
+          some_operation(parsed_data) // 👈 ⚠️ Never executed
+       }
+    }
+  ```
+  This allows to skip the `loop` and return directly the result of awaiting `freeze`.
+
 ## v0.3.1
 
 - Add `DynBoxScope` type for common case of erased future

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nolife"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Crate to open a scope and then freeze it in time for future access."

--- a/README.md
+++ b/README.md
@@ -45,10 +45,8 @@ async fn my_scope(mut time_capsule: nolife::TimeCapsule<MyParsedDataFamily /* �
 -> nolife::Never /* 👈 will be returned from loop */ {
    let mut data = MyData(data_source);
    let mut parsed_data = MyParsedData(&mut data); // imagine that this step is costly...
-   loop /* 👈 will be coerced to a `Never` */ {
-       time_capsule.freeze(&mut parsed_data).await; // gives access to the parsed data to the outside.
-                         /* 👆 reference to the borrowed data */
-   }
+   time_capsule.freeze(&mut parsed_data).await // gives access to the parsed data to the outside.
+                     /* 👆 reference to the borrowed data */
 }
 
 // 3. Open a `BoxScope` using the previously written async function:

--- a/src/counterexamples.rs
+++ b/src/counterexamples.rs
@@ -24,10 +24,7 @@
 //!         let mut scope = BoxScope::new(
 //!             |mut time_capsule: TimeCapsule<CovariantFamily>| async move {
 //!                 let mut f = Covariant { x: "bbb" };
-//!                 loop {
-//!                     time_capsule.freeze(&mut f).await;
-//!                     println!("Called {}", f.x)
-//!                 }
+//!                 time_capsule.freeze(&mut f).await
 //!             },
 //!         );
 //!
@@ -63,10 +60,7 @@
 //!         let mut scope = BoxScope::new(
 //!             |mut time_capsule: TimeCapsule<CovariantFamily>| async move {
 //!                 let mut f = Covariant { x: "bbb" };
-//!                 loop {
-//!                     time_capsule.freeze(&mut f).await;
-//!                     println!("Called {}", f.x)
-//!                 }
+//!                 time_capsule.freeze(&mut f).await
 //!             },
 //!         );
 //!
@@ -102,10 +96,7 @@
 //!             |mut time_capsule: TimeCapsule<CovariantFamily>| async move {
 //!                 let x = String::from("aaaaa");
 //!                 let mut f = Covariant { x: &x };
-//!                 loop {
-//!                     time_capsule.freeze(&mut f).await;
-//!                     println!("Called {}", f.x)
-//!                 }
+//!                 time_capsule.freeze(&mut f).await
 //!             },
 //!         );
 //!
@@ -141,10 +132,7 @@
 //!             |mut time_capsule: TimeCapsule<CovariantFamily>| async move {
 //!                 let x = String::from("aaaaa");
 //!                 let mut f = Covariant { x: &x };
-//!                 loop {
-//!                     time_capsule.freeze(&mut f).await;
-//!                     println!("Called {}", f.x)
-//!                 }
+//!                 time_capsule.freeze(&mut f).await
 //!             },
 //!         );
 //!
@@ -180,10 +168,8 @@
 //!         let mut scope = BoxScope::new(
 //!             |mut time_capsule: TimeCapsule<CovariantDropFamily>| async move {
 //!                 let mut f = CovariantDrop { x: "inner" };
-//!                 loop {
-//!                     println!("Called {}", f.x);
-//!                     time_capsule.freeze(&mut f).await;
-//!                 }
+//!                 println!("Called {}", f.x);
+//!                 time_capsule.freeze(&mut f).await
 //!             },
 //!         );
 //!
@@ -206,6 +192,7 @@
 //!
 //! struct Contravariant<'a> {
 //!     f: Box<dyn FnMut(&'a mut str) + 'a>,
+//!     x: &'a mut str,
 //! }
 //!
 //! struct ContravariantFamily;
@@ -220,20 +207,21 @@
 //!     {
 //!         let mut scope = nolife::BoxScope::new(
 //!             |mut time_capsule: nolife::TimeCapsule<ContravariantFamily>| async move {
-//!                 loop {
 //!                     let mut x = String::from("inner");
 //!
 //!                     let mut f = Contravariant {
 //!                         f: Box::new(|_| {}),
+//!                         x: &mut x,
 //!                     };
-//!                     time_capsule.freeze(&mut f).await;
-//!                     (f.f)(&mut x);
-//!                 }
+//!                     time_capsule.freeze(&mut f).await
 //!             },
 //!         );
 //!
 //!         scope.enter(|f| {
 //!             f.f = Box::new(|inner| outer.set(inner));
+//!         });
+//!         scope.enter(|f| {
+//!             (f.f)(f.x);
 //!         });
 //!     }
 //!     println!("{}", outer.get());
@@ -261,10 +249,7 @@
 //!         let mut scope = BoxScope::new(
 //!             |mut time_capsule: TimeCapsule<CovariantFamily>| async move {
 //!                 let mut f = Covariant { x: "bbb" };
-//!                 loop {
-//!                     time_capsule.freeze(&mut f).await;
-//!                     println!("Called {}", f.x)
-//!                 }
+//!                 time_capsule.freeze(&mut f).await
 //!             },
 //!         );
 //!         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,8 +139,8 @@ mod test {
             |mut time_capsule: TimeCapsule<TimeCapsuleFamily>| async move {
                 let mut inner_scope = BoxScope::new(
                     |mut inner_time_capsule: TimeCapsule<TimeCapsuleFamily>| async move {
-                            // very cursed
-                            time_capsule.freeze(&mut inner_time_capsule).await
+                        // very cursed
+                        time_capsule.freeze(&mut inner_time_capsule).await
                     },
                 );
 


### PR DESCRIPTION
The `Future::Output` type of `FrozenFuture` is now `Never` rather than `()`, which means the `FrozenFuture` never resolves anymore (it is always `Pending`).

This spares the user the need to implicilty prevent the scope from returning with a `loop`, as the call to `freeze` now suffices.

This is a breaking change. See changelog for details.