### PR TITLE
become no_std compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/dureuill/nolife"
 documentation = "https://docs.rs/nolife"
 readme = "README.md"
 keywords = ["ownership", "self-referential", "lifetime", "borrowing"]
-categories = ["rust-patterns"]
+categories = ["rust-patterns", "no-std"]
+
+[features]
+std = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["ownership", "self-referential", "lifetime", "borrowing"]
 categories = ["rust-patterns", "no-std"]
 
 [features]
+default = ["std"]
 std = []
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ struct ContainsScope {
 scope.enter(|parsed_data| { /* do what you need with the parsed data */ });
 ```
 
+# Features
+
+This crate exposes the following Cargo features:
+
+- `std` (default): enable std support and disable `no_std` support.
+  - This feature exists so that disabling it allows an explicit opt-in into [the `no_std` attribute](https://doc.rust-lang.org/reference/names/preludes.html#the-no_std-attribute).
+  - Currently `nolife` does not expose additional APIs available only to the `std` feature, so this feature only exists for backward compatibility at this point.
+  - The `std` feature is enabled by default so that future APIs depending on that feature are available by default
+  - To disable and opt-in into `no_std`, [add `nolife` to your dependencies using `default-features = false`](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features).
+  - `nolife` requires [the `alloc` crate](https://doc.rust-lang.org/alloc/).
+
+
 # Kinds of scopes
 
 This crate only provide a single kind of scope at the moment

--- a/src/box_scope.rs
+++ b/src/box_scope.rs
@@ -75,10 +75,7 @@ where
     /// # Panics
     ///
     /// - If `scope` panics.
-    pub fn new<S: TopScope<Family = T, Future = F>>(scope: S) -> BoxScope<T, F>
-    where
-        S: TopScope<Family = T>,
-    {
+    pub fn new<S: TopScope<Family = T, Future = F>>(scope: S) -> BoxScope<T, F> {
         let raw_scope = Box::new(RawScope::<T, F>::new_uninit());
         let raw_scope: *mut RawScope<T, MaybeUninit<F>> = Box::into_raw(raw_scope);
         struct Guard<Sc> {

--- a/src/box_scope.rs
+++ b/src/box_scope.rs
@@ -1,4 +1,5 @@
-use std::{
+use alloc::boxed::Box;
+use core::{
     future::Future,
     mem::{self, MaybeUninit},
     ptr::NonNull,
@@ -12,7 +13,7 @@ use crate::{raw_scope::RawScope, Family, Never, TopScope};
 /// In exchange, it is fully `'static` and can be moved after creation.
 #[repr(transparent)]
 pub struct BoxScope<T, F: ?Sized = dyn Future<Output = Never> + 'static>(
-    std::ptr::NonNull<RawScope<T, F>>,
+    core::ptr::NonNull<RawScope<T, F>>,
 )
 where
     T: for<'a> Family<'a>,

--- a/src/raw_scope.rs
+++ b/src/raw_scope.rs
@@ -157,7 +157,6 @@ where
     where
         T: for<'a> Family<'a>,
         F: Future<Output = Never>,
-        S: TopScope<Family = T>,
     {
         // SAFETY: precondition (1)
         let RawScopeFields { state, active_fut } = unsafe { Self::fields(this) };

--- a/src/raw_scope.rs
+++ b/src/raw_scope.rs
@@ -1,5 +1,5 @@
 use crate::{waker, Family, Never, TopScope};
-use std::{
+use core::{
     future::Future,
     marker::PhantomData,
     mem::MaybeUninit,
@@ -194,7 +194,7 @@ where
         // SAFETY: precondition (2)
         let active_fut: Pin<&mut F> = unsafe { Pin::new_unchecked(&mut *active_fut) };
 
-        match active_fut.poll(&mut std::task::Context::from_waker(&waker::create())) {
+        match active_fut.poll(&mut core::task::Context::from_waker(&waker::create())) {
             Poll::Ready(never) => match never {},
             Poll::Pending => {}
         }
@@ -223,8 +223,8 @@ where
     type Output = ();
 
     fn poll(
-        mut self: std::pin::Pin<&mut Self>,
-        _cx: &mut std::task::Context<'_>,
+        mut self: core::pin::Pin<&mut Self>,
+        _cx: &mut core::task::Context<'_>,
     ) -> Poll<Self::Output> {
         // SAFETY:
         // - state was set to a valid value in [`TimeCapsule::freeze`]

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,5 +1,5 @@
 //! Defines a generic `Scope` as a trait that can be instantiated as a [`crate::BoxScope`].
-use std::{future::Future, marker::PhantomData};
+use core::{future::Future, marker::PhantomData};
 
 use crate::{Family, Never, TimeCapsule};
 
@@ -12,7 +12,7 @@ impl<P, Family, Future, Output> Sealed for Wrapper<P, Family, Future, Output>
 where
     P: FnOnce(super::TimeCapsule<Family>) -> Future,
     Family: for<'a> crate::Family<'a>,
-    Future: std::future::Future<Output = Output>,
+    Future: core::future::Future<Output = Output>,
 {
 }
 
@@ -52,13 +52,13 @@ struct Wrapper<P, Family, Future, Output>(P, PhantomData<*const Family>)
 where
     P: FnOnce(TimeCapsule<Family>) -> Future,
     Family: for<'a> crate::Family<'a>,
-    Future: std::future::Future<Output = Output>;
+    Future: core::future::Future<Output = Output>;
 
 impl<P, Family, Future, Output> Scope for Wrapper<P, Family, Future, Output>
 where
     P: FnOnce(TimeCapsule<Family>) -> Future,
     Family: for<'a> crate::Family<'a>,
-    Future: std::future::Future<Output = Output>,
+    Future: core::future::Future<Output = Output>,
 {
     type Family = Family;
     type Output = Output;
@@ -85,7 +85,7 @@ pub unsafe fn new_scope<P, Family, Future, Output>(
 where
     P: FnOnce(TimeCapsule<Family>) -> Future,
     Family: for<'a> crate::Family<'a>,
-    Future: std::future::Future<Output = Output>,
+    Future: core::future::Future<Output = Output>,
 {
     Wrapper(producer, PhantomData)
 }
@@ -111,7 +111,6 @@ where
 /// and in particular for error handling.
 /// ```
 /// use nolife::{BoxScope, Scope, SingleFamily, TopScope, scope};
-///
 ///
 /// fn outer_scope(
 ///     input_data: Vec<impl std::io::Read>,

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -1,4 +1,4 @@
-use std::task::{RawWaker, RawWakerVTable, Waker};
+use core::task::{RawWaker, RawWakerVTable, Waker};
 
 pub fn create() -> Waker {
     // Safety: The waker points to a vtable with functions that do nothing. Doing
@@ -6,7 +6,7 @@ pub fn create() -> Waker {
     unsafe { Waker::from_raw(RAW_WAKER) }
 }
 
-const RAW_WAKER: RawWaker = RawWaker::new(std::ptr::null(), &VTABLE);
+const RAW_WAKER: RawWaker = RawWaker::new(core::ptr::null(), &VTABLE);
 const VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake_by_ref, drop);
 
 unsafe fn clone(_: *const ()) -> RawWaker {


### PR DESCRIPTION
Hi there!

I noticed the crate could be made no_std compatible easily enough.
Some tests do depend in `std` so I added a feature to make it optional.

I also fixed a couple warnings. I hope you like it.
Please feel free to change anything as you prefer.